### PR TITLE
Specify local host/port in config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,9 @@ github: https://github.com/katydecorah/font-library
 
 angular: 1.3.15
 
+port: 4000
+host: 127.0.0.1
+
 exclude:
   - "*.lock"
   - "Gemfile"


### PR DESCRIPTION
Adding specific host/port to config so that jekyll status info in terminal will also resolve in browser.
