### PR TITLE
Fixing typo that was generating 2 slab tags

### DIFF
--- a/families.json
+++ b/families.json
@@ -34,7 +34,7 @@
   { "family": "Amethysta", "tags": [] },
   { "family": "Amiri", "tags": [ "1900s", "elegant" ] },
   { "family": "Anaheim", "tags": [ "terminal" ] },
-  { "family": "Andada", "tags": [ "slab "] },
+  { "family": "Andada", "tags": [ "slab"] },
   { "family": "Andika", "tags": [ "literacy" ] },
   { "family": "Angkor", "tags": [] },
   { "family": "Annie Use Your Telescope", "tags": [ "scrawl"] },


### PR DESCRIPTION
Noticed there were 2 SLAB tags. Looking at the `families.json` I see there's a typo `"slab "` should be just `"slab"`.

Fixed.

Thanks,
Mark  
