### PR TITLE
creates "needs tag" filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Font Library is built with [Jekyll](http://jekyllrb.com/) and [AngularJS](https:
 
 Each font family is stored as an object in `families.json`. Each family has an array of tags.
 
+### Help wanted
+
+You're welcome to edit `families.json` to add, edit, or improve tags. I recommend starting by tagging fonts that you often want to find for yourself -- curate your own tag! It's likely that someone else will dig your collection.
+
+Click the **Needs tags** button to show all fonts that haven't been tagged yet:
+
+![image](https://cloud.githubusercontent.com/assets/2180540/8320903/29c5dbc8-19ee-11e5-8489-1f5cf7f32b5e.png)
+
+Add tags to `families.json` as described in the next sections.
+
 ### Adding/editing `families.json` guidelines
 
 * Use double quotes `"`
@@ -23,18 +33,6 @@ Each font family is stored as an object in `families.json`. Each family has an a
 * The family name must match the Google Font family name exactly
 
 [View families.json](https://github.com/katydecorah/font-library/blob/gh-pages/families.json)
-
-### Help wanted
-
-You're welcome to edit `families.json` to add, edit, or improve tags. I recommend starting by tagging fonts that you often want to find for yourself -- curate your own tag! It's likely that someone else will dig your collection.
-
-Want to help, but don't know where to start? Open your browser's Console:
-
-![image](https://cloud.githubusercontent.com/assets/2180540/7384122/3632875a-edfa-11e4-8e91-37c9c017e8df.png)
-
-* **Help wanted! These fonts need to be added to families.json** &mdash; if Google adds a new font, but we haven't added it to `families.json` yet, then the Console will log it along with the exact entry you can copy and paste into `families.json`. Feel free to add additional tags to the entry.
-* **New font alert!** &mdash; if a family has less than 2 tags, then the Console will log it. Open the provided link to the specimen page and read the description to get ideas for tags. Try to use tags that are already established, but create new tags when necessary.
-
 
 ### Creating a pull request or issue
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,7 @@
 <link href='http://fonts.googleapis.com/css?family=Unica+One' rel='stylesheet' type='text/css'>
 <!-- gets google font-->
 <link ng-href="http://fonts.googleapis.com/css?family=[[font.family.replace(' ','+')]][[ font.variants.indexOf('regular') < 0 && font.variants.indexOf('italic') >= 0 && ':' + font.variants[0] || '' ]][[ font.variants.indexOf('regular') < 0 && font.variants.indexOf('italic') < 0 && ':'+font.variants[0] || '' ]][[ font.subsets.indexOf('latin') >=0 && '&text=' + font.family.replace(' ','+') || '']]"  rel="stylesheet" ng-repeat="font in searchCount=( data |
-filter:{ tags: selectedTags, variants:selectedVariants, subsets:selectedSubsets, category:selectedCategory }:true ) | startFrom: (currentPage - 1) * pageSize | limitTo:pageSize">
+filter:{ tags: selectedTags, count:tagCount, variants:selectedVariants, subsets:selectedSubsets, category:selectedCategory }:true ) | startFrom: (currentPage - 1) * pageSize | limitTo:pageSize">
 <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/{{site.angular}}/angular.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
 </head>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -149,6 +149,21 @@ header {
   &[disabled] { display: none; }
 }
 
+.btn-small {
+  border-radius: .5em;
+  box-shadow: none;
+  cursor: pointer;
+  font-size: .8em;
+  height: 21px;
+  padding-top: 2px;
+
+  &.active {
+    background: $accent;
+    color: $white;
+  }
+
+}
+
 .btn-group {
 
   display: inline-block;

--- a/index.html
+++ b/index.html
@@ -48,6 +48,8 @@ tag: cursive
 		<button ng-class="{'active':selectedOrder === 'recent'}" class="btn" ng-click="selectedOrder = 'recent';order('-lastModified',false)" title="Recently updated or added">↑</button><button ng-class="{'active':selectedOrder === 'older'}" class="btn" ng-click="selectedOrder = 'older';order('lastModified',false)">↓</button><button ng-class="{'active':selectedOrder === 'alpha'}" class="btn" ng-click="selectedOrder = 'alpha';order('family',false)">A-Z</button>
 	</div>
 
+	<label class="btn btn-small" ng-class="{active:tagCount === 0 }"><input ng-model="tagCount" type="checkbox" ng-true-value="0" ng-false-value="undefined" class="hide" ng-change="resetPagination()">Needs tags</label>
+
 	<div ng-model="settings" ng-class="{active:settings}" ng-click="showDetails =! showDetails; settings =! settings" class="btn-settings">{% include settings.svg %}</div>
 </div>
 
@@ -60,7 +62,7 @@ tag: cursive
 	<div class="families">
 		<!-- individual font -->
 		<div class="family" ng-repeat="font in searchCount=( data |
-		filter:{ tags: selectedTags, variants:selectedVariants, subsets:selectedSubsets, category:selectedCategory }:true ) | startFrom: (currentPage - 1) * pageSize | limitTo:pageSize">
+		filter:{ tags: selectedTags, count:tagCount, variants:selectedVariants, subsets:selectedSubsets, category:selectedCategory }:true ) | startFrom: (currentPage - 1) * pageSize | limitTo:pageSize">
 		<!-- links to google font page -->
 		<a ng-href="http://www.google.com/fonts#UsePlace:use/Collection:[[font.family.replace(' ','+')]]" class="family-link">
 			<!-- builds the inline styles & displays font name -->

--- a/index.html
+++ b/index.html
@@ -88,8 +88,12 @@ tag: cursive
 				|
 				<span class="meta" data-title="[[font.subsets.join(', ')]]">[[font.subsets.length == 1 && font.subsets.length + " subset" || font.subsets.length + " subsets"]]</span>
 			</div>
-			<!-- link to the font's spec -->
-			<a ng-href="https://www.google.com/fonts/specimen/[[font.family.replace(' ','+')]]" class="btn small quiet float-right" target="_blank">&#8505;</a>
+			<div class="float-right">
+				<!-- link to the font's spec -->
+				<a ng-href="https://www.google.com/fonts/specimen/[[font.family.replace(' ','+')]]" class="meta btn small quiet" target="_blank">&#8505;</a>
+				<!-- link to line number -->
+				<a ng-href="https://github.com/katydecorah/font-library/blob/gh-pages/families.json#L[[font.lineNumber]]" class="meta btn small quiet" target="_blank">&#9998;</a>
+			</div>
 		</div>
 	</div>
 </div>

--- a/js/app.js
+++ b/js/app.js
@@ -80,7 +80,8 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
           'variants': obj2[i].variants,
           'subsets': obj2[i].subsets,
           'category': obj2[i].category,
-          'lastModified': obj2[i].lastModified
+          'lastModified': obj2[i].lastModified,
+          'lineNumber': parseInt(i) + 2
         });
       } else {
         console.log( 'Something is wrong, cc/' + obj1[i].family);

--- a/js/app.js
+++ b/js/app.js
@@ -56,8 +56,6 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
   $http.get('families.json')
   .then(function(res){
     $scope.dataTemp = res.data;
-
-    $scope.helpWantedTags();
     $scope.helpWantedNewFont();
   });
 
@@ -78,6 +76,7 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
         result.push({
           'family' : obj1[i].family,
           'tags' : obj1[i].tags,
+          'count': obj1[i].tags.length,
           'variants': obj2[i].variants,
           'subsets': obj2[i].subsets,
           'category': obj2[i].category,
@@ -89,19 +88,6 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
     }
     return result;
   }
-
-  // reiterate this
-  /* log fonts that only have less than 1 tag */
-  $scope.helpWantedTags = function() {
-    console.groupCollapsed("Help wanted! These fonts need more tags in families.json");
-    console.info("These fonts need more tags, add them to https://github.com/katydecorah/font-library/blob/gh-pages/families.json. Learn more about the font by following the provided link to the font's specimen.");
-    angular.forEach($scope.dataTemp, function(key) {
-      if (key.tags.length < 1) {
-        console.log(key.family + "\n\tDescription: https://www.google.com/fonts/specimen/"+key.family.split(" ").join("+"));
-      }
-    });
-    console.groupEnd();
-  };
 
   // reiterate this
   /* log new fonts - fonts that needs to be added to families.json */


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2180540/8320903/29c5dbc8-19ee-11e5-8489-1f5cf7f32b5e.png)

Adds a “needs tag” button to filter all fonts that _haven’t_ been tagged (instead of logging to console).
