### PR TITLE
Match Google Fonts and DNS prefetch call :lock:

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,9 +13,9 @@
 <meta name="twitter:domain" content="{{site.url}}{{site.baseurl}}">
 <link rel="dns-prefetch" href="https://fonts.googleapis.com">
 <link rel="stylesheet" href="{{site.baseurl}}/css/style.css">
-<link href='http://fonts.googleapis.com/css?family=Unica+One' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Unica+One' rel='stylesheet' type='text/css'>
 <!-- gets google font-->
-<link ng-href="http://fonts.googleapis.com/css?family=[[fontCall(font)]]" rel="stylesheet" ng-repeat="font in searchCount=( data |
+<link ng-href="https://fonts.googleapis.com/css?family=[[fontCall(font)]]" rel="stylesheet" ng-repeat="font in searchCount=( data |
 filter:{ tags: selectedTags, count:tagCount, variants:selectedVariants, subsets:selectedSubsets, category:selectedCategory, family:selectedFamily }:true ) | orderBy: familySorter | startFrom: starter | limitTo:pageSize">
 <style>
 [[previewStyles]]


### PR DESCRIPTION
Switched Google Fonts stylesheet call to us HTTPS so that the DNS prefetch matches.
