### PR TITLE
Change travis.yml node version to "stable"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
-node_js: "0.10"
+node_js: "stable"
 before_install: gem install scss-lint
 sudo: false


### PR DESCRIPTION
@katydecorah I noticed that the [latest build](https://travis-ci.org/katydecorah/font-library/builds/95717418) was throwing a bunch of warnings about the Node version (0.10) specified in travis.yml. 

I switched it to "stable" since none of the dependencies seem to need an old version of Node  :smile:   
