### PR TITLE
adds basic search

### DIFF
--- a/_includes/filters.html
+++ b/_includes/filters.html
@@ -1,41 +1,41 @@
 <div class="controls" ng-class="{ active: showDetails}">
-  
+
   <input type="text" id="custom-preview" value="" placeholder="Custom text preview&hellip;" ng-model="customPreview">
   
-  <select class="select-tags" ng-model="selectedTags" ng-change="resetPagination();removeFamily()" aria-label="Tag">
+  <select class="select-tags" ng-model="selectedTags" ng-change="resetPagination();" aria-label="Tag">
     <option value="" selected disabled>tag</option>
     <option ng-selected="[[ tag.tag == selectedTags ]]" ng-repeat="tag in tags" value="[[tag.tag]]">[[tag.tag]]</option>
   </select>
-  
-  <select ng-model="selectedCategory" ng-show="categories" ng-change="resetPagination();setSearch('category',selectedCategory);removeFamily()" aria-label="Category">
+
+  <select ng-model="selectedCategory" ng-show="categories" ng-change="resetPagination();setSearch('category',selectedCategory);" aria-label="Category">
     <option value="" selected disabled>category</option>
     <option ng-selected="[[ key.category == selectedCategory ]]" ng-repeat="key in categories | orderBy: 'category' " value="[[key.category]]">[[key.category]]</option>
   </select>
-  
-  <select ng-model="selectedSubsets" ng-show="subsets" ng-change="resetPagination();setSearch('subset',selectedSubsets);removeFamily()" aria-label="Subset">
+
+  <select ng-model="selectedSubsets" ng-show="subsets" ng-change="resetPagination();setSearch('subset',selectedSubsets);" aria-label="Subset">
     <option value="" selected disabled>subset</option>
     <option ng-selected="[[ key.subset == selectedSubsets ]]" ng-repeat="key in subsets | orderBy: 'subset' " value="[[key.subset]]">[[key.subset]]</option>
   </select>
-  
-  <select ng-model="selectedVariants" ng-show="variants" ng-change="resetPagination();setSearch('variant',selectedVariants);removeFamily()" aria-label="Variant">
+
+  <select ng-model="selectedVariants" ng-show="variants" ng-change="resetPagination();setSearch('variant',selectedVariants);" aria-label="Variant">
     <option value="" selected disabled>variant</option>
     <option ng-selected="[[ key.variant == selectedVariants ]]" ng-repeat="key in variants | orderBy: 'variant' " value="[[key.variant]]">[[key.variant]]</option>
   </select>
-  
+
   <!--
-  <select ng-model="selectedVariantCount" ng-show="variants" ng-change="resetPagination();setSearch('variantCount',selectedVariantCount);removeFamily()" aria-label="Variant Count" ng-options="item.count as item.count for item in variantCount track by item.count">
+  <select ng-model="selectedVariantCount" ng-show="variants" ng-change="resetPagination();setSearch('variantCount',selectedVariantCount);" aria-label="Variant Count" ng-options="item.count as item.count for item in variantCount track by item.count">
     <option value="">number of variants</option>
-  </select> 
+  </select>
 -->
 
-  
+
   <label class="small"><input class="checkbox" type="checkbox" ng-model="fullVariant" value=""> has bold, italic, and regular</label>
-  
+
   <button ng-click="clearFilters();" class="btn btn-clear" ng-show="selectedTags || selectedCategory || selectedVariants || selectedSubsets || selectedVariantCount || fullVariant || customPreview">Clear</button>
-    
+
 </div>
 <!-- advanced search -->
-<div class="control-container">		
+<div class="control-container">
   <div class="btn-group">
     <div class="btn" ng-class="{'active':familySorter == 'family'|| familySorter == '-family'} ">
       <label ng-hide="familySorter == 'family'"><input type="radio" name="familySorter" ng-model="familySorter" value="family">A-Z <span ng-hide="familySorter == 'lastModified' || familySorter == '-lastModified'">↑</span></label>
@@ -45,6 +45,6 @@
       <label ng-hide="familySorter == 'lastModified' || familySorter == 'family' || familySorter == '-family'"><input type="radio" name="familySorter" ng-model="familySorter" value="lastModified">Date ↓</label>
     </div>
   </div>
-  
+
   <div ng-model="settings" ng-class="{active:settings}" ng-click="showDetails =! showDetails; settings =! settings" class="btn-settings">{% include settings.svg %}</div>
 </div>

--- a/_includes/filters.html
+++ b/_includes/filters.html
@@ -1,7 +1,7 @@
 <div class="controls" ng-class="{ active: showDetails}">
 
   <input type="text" id="custom-preview" value="" placeholder="Custom text preview&hellip;" ng-model="customPreview">
-  
+
   <select class="select-tags" ng-model="selectedTags" ng-change="resetPagination();" aria-label="Tag">
     <option value="" selected disabled>tag</option>
     <option ng-selected="[[ tag.tag == selectedTags ]]" ng-repeat="tag in tags" value="[[tag.tag]]">[[tag.tag]]</option>
@@ -31,7 +31,7 @@
 
   <label class="small"><input class="checkbox" type="checkbox" ng-model="fullVariant" value=""> has bold, italic, and regular</label>
 
-  <button ng-click="clearFilters();" class="btn btn-clear" ng-show="selectedTags || selectedCategory || selectedVariants || selectedSubsets || selectedVariantCount || fullVariant || customPreview">Clear</button>
+  <button ng-click="clearFilters();" class="btn btn-clear" ng-show="selectedTags || selectedCategory || selectedVariants || selectedSubsets || selectedVariantCount || fullVariant || customPreview || search">Clear</button>
 
 </div>
 <!-- advanced search -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,7 +16,7 @@
 <link href='https://fonts.googleapis.com/css?family=Unica+One' rel='stylesheet' type='text/css'>
 <!-- gets google font-->
 <link ng-href="https://fonts.googleapis.com/css?family=[[fontCall(font)]]" rel="stylesheet" ng-repeat="font in searchCount=( data |
-filter:{ tags: selectedTags, count:tagCount, variants:selectedVariants, subsets:selectedSubsets, category:selectedCategory, variantCount: (selectedVariantCount || undefined), family:selectedFamily, fullVariant:(fullVariant || undefined) }:true | filter:search) | orderBy: familySorter | startFrom: starter | limitTo:pageSize">
+filter:{ tags: selectedTags, count:tagCount, variants:selectedVariants, subsets:selectedSubsets, category:selectedCategory, variantCount: (selectedVariantCount || undefined), fullVariant:(fullVariant || undefined) }:true | filter:search) | orderBy: familySorter | startFrom: starter | limitTo:pageSize">
 <style>
 [[previewStyles]]
 </style>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,7 +16,7 @@
 <link href='https://fonts.googleapis.com/css?family=Unica+One' rel='stylesheet' type='text/css'>
 <!-- gets google font-->
 <link ng-href="https://fonts.googleapis.com/css?family=[[fontCall(font)]]" rel="stylesheet" ng-repeat="font in searchCount=( data |
-filter:{ tags: selectedTags, count:tagCount, variants:selectedVariants, subsets:selectedSubsets, category:selectedCategory, variantCount: (selectedVariantCount || undefined), family:selectedFamily, fullVariant:(fullVariant || undefined) }:true ) | orderBy: familySorter | startFrom: starter | limitTo:pageSize">
+filter:{ tags: selectedTags, count:tagCount, variants:selectedVariants, subsets:selectedSubsets, category:selectedCategory, variantCount: (selectedVariantCount || undefined), family:selectedFamily, fullVariant:(fullVariant || undefined) }:true | filter:search) | orderBy: familySorter | startFrom: starter | limitTo:pageSize">
 <style>
 [[previewStyles]]
 </style>

--- a/_includes/search-status.html
+++ b/_includes/search-status.html
@@ -2,7 +2,6 @@
   <span ng-show="searchCount.length == 0" class="ng-hide">Dang! Nothing</span>
   <span ng-hide="searchCount.length == 0">Found [[searchCount.length == 1 && searchCount.length + " font" || searchCount.length + " fonts"]]</span><span ng-show="selectedTags || selectedCategory || selectedVariants || selectedSubsets"> for </span><span class="family-tag active" ng-show="selectedTags" ng-click="removeTag()">[[selectedTags]]</span><span class="family-tag active  no-hash" ng-show="selectedCategory" ng-click=removeCategory()> [[selectedCategory]]</span><span class="family-tag active no-hash" ng-show="selectedVariants" ng-click="removeVariant()"> [[selectedVariants]]</span><span class="family-tag active no-hash" ng-show="selectedSubsets" ng-click="removeSubset()"> [[selectedSubsets]]</span>
   <span ng-show="tagCount === 0"> that <label class="family-tag active no-hash" ng-class="{active:tagCount === 0 }"><input ng-model="tagCount" type="checkbox" ng-true-value="0" ng-false-value="undefined" class="hide" ng-change="resetPagination(); removeTag()">Need tags</label></span>
-  <span ng-show="selectedFamily">by name</span>
   <span ng-show="selectedVariantCount"> with [[selectedVariantCount]] variant[[selectedVariantCount == 1 && ' ' || 's']]</span>
   <span ng-show="fullVariant" ng-click="removeFullVariants()" class="no-hash family-tag active"> with full variants</span>
   <span ng-show="search" class="no-hash family-tag active" ng-click="removeSearch()"> &ldquo;[[search]]&rdquo;</span>

--- a/_includes/search-status.html
+++ b/_includes/search-status.html
@@ -5,4 +5,5 @@
   <span ng-show="selectedFamily">by name</span>
   <span ng-show="selectedVariantCount"> with [[selectedVariantCount]] variant[[selectedVariantCount == 1 && ' ' || 's']]</span>
   <span ng-show="fullVariant" ng-click="removeFullVariants()" class="no-hash family-tag active"> with full variants</span>
+  <span ng-show="search" class="no-hash family-tag active" ng-click="removeSearch()"> &ldquo;[[search]]&rdquo;</span>
 </div>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -32,5 +32,5 @@
   </div>
   <hr>
   <div class="tag-heading">Want to help the project?</div>
-  <p>Sort by fonts that <label class="family-tag no-hash" ng-class="{active:tagCount === 0 }"><input ng-model="tagCount" type="checkbox" ng-true-value="0" ng-false-value="undefined" class="hide" ng-change="resetPagination(); removeTag(); removeFamily()">Need tags</label> and then <a href="{{site.contributing}}">check out how to contribute</a>.</p>
+  <p>Sort by fonts that <label class="family-tag no-hash" ng-class="{active:tagCount === 0 }"><input ng-model="tagCount" type="checkbox" ng-true-value="0" ng-false-value="undefined" class="hide" ng-change="resetPagination(); removeTag(); ">Need tags</label> and then <a href="{{site.contributing}}">check out how to contribute</a>.</p>
 </div>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,6 +1,10 @@
+<input type="search" ng-model="search" placeholder="Search&hellip;" ng-change="setSearch('search',search)">
+
+<hr>
+
 <!-- tag index -->
 <div class="tags">
-  
+
   <div class="btn-group-inputs">
     <div class="btn-group" ng-init="tagView = 'list'">
       <div class="btn" ng-class="{'active':tagView == 'list'}">
@@ -10,9 +14,9 @@
       </div>
     </div>
   </div>
-  
+
   <div id="tags" class="tags-container" ng-class="{'show-table':tagView == 'table'} ">
-    
+
     <div class="tag-header" ng-show="tagView == 'table'">
       <div class="tag-header-tag" ng-class="{'active':sorter == 'tag'|| sorter == '-tag'} ">
         <label ng-hide="sorter == 'tag'"><input type="radio" name="sorter" ng-model="sorter" value="tag">Tag <span ng-hide="sorter == 'value' || sorter == '-value'">↑</span></label>
@@ -22,20 +26,11 @@
         <label ng-hide="sorter == '-value' || sorter == 'tag' || sorter == '-tag'"><input type="radio" name="sorter" ng-model="sorter" value="-value">Count ↓</label>
       </div>
     </div>
-    
+
     <button ng-repeat="tag in tags | orderBy: sorter " class="family-tag" ng-class="{active: tag.tag == selectedTags}" name="tag" ng-model="selectedTags" value="[[tag.tag]]" ng-click="selectTag(tag.tag);">[[tag.tag]] <span class="tag-count" ng-show="tagView == 'table'">[[tag.value]]</span>
     </button>
   </div>
   <hr>
   <div class="tag-heading">Want to help the project?</div>
   <p>Sort by fonts that <label class="family-tag no-hash" ng-class="{active:tagCount === 0 }"><input ng-model="tagCount" type="checkbox" ng-true-value="0" ng-false-value="undefined" class="hide" ng-change="resetPagination(); removeTag(); removeFamily()">Need tags</label> and then <a href="{{site.contributing}}">check out how to contribute</a>.</p>
-</div>
-
-<div class="by-name">
-  <hr>
-  <div class="tag-heading">Find a font by name</div>
-  <select ng-model="selectedFamily" ng-change="setSearch('family',selectedFamily);removeTag();removeSubset();removeVariant();removeCategory();tagCount = undefined">
-    <option value="" selected disabled>Families</option>
-    <option ng-repeat="font in data | orderBy: 'family'">[[font.family]]</option>
-  </select>
 </div>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -1,27 +1,27 @@
 .container {
-  
+
   @extend %clearfix;
-  
-  
+
+
   margin: 0 auto;
   max-width: $container-width;
   position: relative;
-  
+
   @include breakpoint(medium) {
     padding: 0 1em;
   }
 }
 
 header {
-  
+
   @extend %tight;
-  
+
   background: $accent;
   border-bottom: 1px solid $body-bg;
   font-size: 1.2em;
   margin-bottom: 1em;
   padding: .25em 1em;
-  
+
   @include breakpoint(medium-up) {
     font-size: $font-size;
     height: 35px;
@@ -33,50 +33,50 @@ header {
     width: 100%;
     z-index: 1;
   }
-  
+
   @include breakpoint(medium) {
     padding: .25em .75em;
   }
-  
+
   .title {
     color: $white;
-    
+
     &:hover {
       color: $white;
       text-decoration: underline;
     }
-    
+
   }
-  
+
   .subtitle {
     color: rgba($white, .55);
-    
+
     &:hover {
       color: rgba($white, .55);
       text-decoration: underline;
     }
-    
+
   }
-  
+
 }
 
 .content {
   max-width: 40em;
   position: relative;
-  
+
   @include breakpoint(medium-up) {
     float: right;
     padding-bottom: 5em;
     padding-top: 2em;
     width: 65%;
   }
-  
+
 }
 
 .sidebar {
-  
+
   display: none;
-  
+
   @include breakpoint(medium-up) {
     border-right: 1px dashed rgba($text-color, .2);
     display: block;
@@ -89,27 +89,27 @@ header {
     top: 35px;
     width: 30%;
   }
-  
+
 }
 
 
 
 .select-tags {
-  
+
   @include breakpoint(medium-up) {
     display: none;
   }
-  
+
 }
 
 select {
-  
+
   @extend %upper;
-  
+
   @extend %round;
-  
+
   @extend %tight;
-  
+
   background: lighten($body-bg, 2%);
   border: 1px solid;
   color: $selected-tag;
@@ -129,33 +129,33 @@ input {
   height: 22px;
   line-height: 1.5;
   padding: 0 .5em;
-  
+
   @include placeholder {
     color: lighten($selected-tag, 15%);
     font-family: $sans;
     text-transform: uppercase;
   }
-   
+
 }
 
 
 .search-status {
   @extend %clearfix;
-  
+
   margin-bottom: .5em;
   margin-top: 1em;
-  
+
   .family-tag {
     margin-left: .25em;
     margin-right: .25em;
     position: relative;
   }
-  
+
   .family-tag:hover {
     color: $accent;
     cursor: pointer;
   }
-  
+
   .family-tag:hover:after {
     content: '\00D7';
     font-size: 5em;
@@ -166,18 +166,18 @@ input {
     top: -.35em;
     width: 100%;
   }
-  
+
 }
 
 .no-results {
-  
+
   @extend %fade;
-  
+
   -webkit-animation: fade $transition * 2 forwards 1s;
   animation: fade $transition * 2 forwards 1s;
   font-size: 1.25em;
   margin-top: 3em;
-  
+
 }
 
 
@@ -185,9 +185,9 @@ input {
   margin-bottom: .5em;
   padding-bottom: 1em;
   position: relative;
-  
+
   @include breakpoint(medium-up) {
-    border-bottom: 1px dashed rgba(58, 56, 44, .2);
+    border-bottom: 1px dashed $hr-color;
     margin-top: -5em;
     padding-top: 1em;
     -ms-transform: translateY(-3.75em);
@@ -195,15 +195,15 @@ input {
     transform: translateY(-3.75em);
     transition: $transition;
   }
-  
+
   @include breakpoint(medium) {
-    
+
     select {
       border-radius: 0;
       margin-bottom: .5em;
     }
   }
-  
+
   &.active {
     margin-top: 0;
     -ms-transform: translateY(.5em);
@@ -211,28 +211,28 @@ input {
     transform: translateY(.5em);
     transition: $transition;
   }
-  
+
   label {
     display: inline-block;
     margin: .25em;
   }
-  
+
   .checkbox {
     position: relative;
-    top: 5px;    
+    top: 5px;
   }
-  
+
 }
 
 .control-container {
   position: relative;
-  
-  
+
+
   @include breakpoint(medium-up) {
     float: right;
     top: 18px;
   }
-  
+
   @include breakpoint(medium-down) {
     margin-bottom: 1em;
   }
@@ -245,16 +245,16 @@ hr {
 }
 
 .show-table {
-  
+
   .family-tag {
     display: block;
     text-align: left;
     width: 100%;
   }
-  
+
   .tag-count {
     float: right;
     width: 2em;
   }
-  
+
 }

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -3,6 +3,7 @@ $body-bg: #f0eee7;
 $header-bg: #2c3e50;
 $sidebar-bg: #c5bfa0;
 $search-bg: #34495e;
+$hr-color: rgba(58, 56, 44, .2);
 $accent: #db4053;
 $white: #fff;
 $black: #000;

--- a/index.html
+++ b/index.html
@@ -8,15 +8,15 @@ layout: default
 
 <main class="content">
 	{% include filters.html %}
-	{% include search-status.html %}	
+	{% include search-status.html %}
 	<div class="families" id="families">
 		<!-- individual font -->
 		<div class="family" ng-repeat="font in searchCount=( data |
-		filter:{ tags: selectedTags, count:tagCount, variants:selectedVariants, subsets:selectedSubsets, category:selectedCategory, variantCount: (selectedVariantCount || undefined), family: selectedFamily, fullVariant:(fullVariant || undefined) }:true ) | orderBy: familySorter | startFrom: starter | limitTo:pageSize">
+		filter:{ tags: selectedTags, count:tagCount, variants:selectedVariants, subsets:selectedSubsets, category:selectedCategory, variantCount: (selectedVariantCount || undefined), family: selectedFamily, fullVariant:(fullVariant || undefined) }:true | filter:search ) | orderBy: familySorter | startFrom: starter | limitTo:pageSize">
 		<!-- links to google font page -->
 		<a ng-href="http://www.google.com/fonts#UsePlace:use/Collection:[[font.family.replace(' ','+')]]" class="family-link[[ (selectedSubsets.indexOf('hebrew') == 0 || selectedSubsets.indexOf('arabic') == 0) && ' language-rtl' || '' ]]" title="Font: [[font.family]]">
 			<!-- builds the inline styles & displays font name -->
-			<div class="family-title" style="[[familyStyle(font)]]">				
+			<div class="family-title" style="[[familyStyle(font)]]">
 				[[ languageSample(font) ]]
 				<span class="family-name[[ (font.subsets.indexOf('latin') < 0 || selectedSubsets.indexOf('latin') < 0 ) && ' family-title-small'|| '']]">[[customPreview && customPreview || font.family]]</span>
 			</div>
@@ -46,7 +46,7 @@ layout: default
 </div>
 
 <section class="preview-container" ng-class="{active: preview}">
-	<div class="container preview" style="font-family: '[[preview]]';">		
+	<div class="container preview" style="font-family: '[[preview]]';">
 		<div class="btn-close" ng-click="selectPreview(undefined)">&times;</div>
 		<p>Previewing: <a ng-href="http://www.google.com/fonts#UsePlace:use/Collection:[[preview.replace(' ','+')]]">[[preview]]</a></p>
 		<div ng-click="selectPreview(undefined)">

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ layout: default
 	<div class="families" id="families">
 		<!-- individual font -->
 		<div class="family" ng-repeat="font in searchCount=( data |
-		filter:{ tags: selectedTags, count:tagCount, variants:selectedVariants, subsets:selectedSubsets, category:selectedCategory, variantCount: (selectedVariantCount || undefined), family: selectedFamily, fullVariant:(fullVariant || undefined) }:true | filter:search ) | orderBy: familySorter | startFrom: starter | limitTo:pageSize">
+		filter:{ tags: selectedTags, count:tagCount, variants:selectedVariants, subsets:selectedSubsets, category:selectedCategory, variantCount: (selectedVariantCount || undefined), fullVariant:(fullVariant || undefined) }:true | filter:search ) | orderBy: familySorter | startFrom: starter | limitTo:pageSize">
 		<!-- links to google font page -->
 		<a ng-href="http://www.google.com/fonts#UsePlace:use/Collection:[[font.family.replace(' ','+')]]" class="family-link[[ (selectedSubsets.indexOf('hebrew') == 0 || selectedSubsets.indexOf('arabic') == 0) && ' language-rtl' || '' ]]" title="Font: [[font.family]]">
 			<!-- builds the inline styles & displays font name -->

--- a/js/app.js
+++ b/js/app.js
@@ -32,7 +32,7 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
     'thai':'สวัสดีชาวโลก',
     'vietnamese':'xin chào'
   };
-  
+
   $scope.$watch(function () { return $location.url(); }, function () {
     var path = $location.path().split('/'),
     locationSearch = path[1],
@@ -40,6 +40,7 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
     $scope.selectedCategory = $location.search().category;
     $scope.selectedSubsets = $location.search().subset;
     $scope.selectedVariants = $location.search().variant;
+    $scope.search = $location.search().search;
     $scope.selectedVariantCount = parseInt($location.search().variantCount);
     $scope.selectedFamily = $location.search().family;
     if ($.isNumeric(locationSearch)) {
@@ -65,20 +66,20 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
       $scope.selectedTags = locationSearch.split('+').join(' ');
     }
   });
-  
-  
+
+
   $http.get('families.json')
   .then(function(res){
     $scope.dataTemp = res.data;
     $scope.helpWantedNewFont();
   });
-  
+
   // merges families.json and Google Fonts API
   $http.get($scope.url).success(function(res){
     $scope.api = res.items;
     $scope.data = merge($scope.dataTemp,$scope.api);
     // create unique tag array
-    $scope.tags = _.map(  
+    $scope.tags = _.map(
       _.chain($scope.data)
       .pluck('tags')
       .flatten()
@@ -87,7 +88,7 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
         return { tag: key, value: num }
       });
       // create unique variants array
-      $scope.variants = _.map(  
+      $scope.variants = _.map(
         _.chain($scope.data)
         .pluck('variants')
         .flatten()
@@ -96,16 +97,16 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
           return { variant: key }
         });
         // create unique variant count array
-        $scope.variantCount = _.map(  
+        $scope.variantCount = _.map(
           _.chain($scope.data)
           .pluck('variantCount')
           .flatten()
           .countBy()
           .value() , function (num,key) {
-            return  { count: parseInt(key) } 
+            return  { count: parseInt(key) }
           });
         // create unique subset array
-        $scope.subsets = _.map(  
+        $scope.subsets = _.map(
           _.chain($scope.data)
           .pluck('subsets')
           .flatten()
@@ -114,7 +115,7 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
             return { subset: key }
           });
           // create unique category array
-          $scope.categories = _.map(  
+          $scope.categories = _.map(
             _.chain($scope.data)
             .pluck('category')
             .flatten()
@@ -126,7 +127,7 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
             // If app can't connect to Google Font API then just use families.json data
             $scope.data = $scope.dataTemp;
           });
-          
+
           // reiterate: this breaks when the APIs aren't 1:1
           function merge(obj1,obj2) {
             var result = [];
@@ -135,7 +136,7 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
               var match = _.where(obj2, {family: obj1[i].family});
               if (match) {
                 // if there's a match push it to the final dataarray
-                
+
                 // Check for main variants
                 var hasItalic = false, hasBold = false,hasRegular = false,fullVariant = false;
                 if ( match[0].variants.indexOf('italic') != -1 ) {
@@ -147,11 +148,11 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
                 if ( match[0].variants.indexOf('500') != -1 || match[0].variants.indexOf('600') != -1 || match[0].variants.indexOf('700') != -1 || match[0].variants.indexOf('800') != -1 || match[0].variants.indexOf('900') != -1 ) {
                   hasBold = true;
                 }
-                
+
                 if (hasBold && hasRegular && hasItalic) {
                   fullVariant = true
                 }
-                
+
                 result.push({
                   'family' : obj1[i].family,
                   'tags' : obj1[i].tags,
@@ -176,19 +177,19 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
           $scope.helpWantedNewFont = function() {
             var storedFamilies = [],
             apiFamilies = [];
-            
+
             angular.forEach($scope.dataTemp, function(key) {
               storedFamilies.push(key.family);
             });
-            
+
             $http.get($scope.url)
             .then(function(res){
               $scope.api = res.data.items;
-              
+
               angular.forEach($scope.api, function(key) {
                 apiFamilies.push(key.family);
               });
-              
+
               var needToAdd = _.difference(apiFamilies,storedFamilies);
               if (needToAdd.length) {
                 console.groupCollapsed("New font alert!");
@@ -205,22 +206,22 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
               }
             });
           };
-          
+
           $scope.sendAnalytics = function() {
             $window.ga('send', 'pageview', { page: '/#'+$location.url() });
           };
-          
+
           $scope.updateLocation = function() {
             $location.path("/"+$scope.selectedTags.replace(' ','+'));
             $scope.sendAnalytics();
           };
-          
+
           $scope.reset = function() {
             $location.path("");
           };
-          
+
           $scope.updateLocPage = function(i) {
-            
+
             if( $scope.selectedTags) {
               $location.path("/"+$scope.selectedTags.replace(' ','+')+"/"+ ($scope.currentPage));
             } else {
@@ -229,7 +230,7 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
             window.scrollTo(0, 0);
             $scope.sendAnalytics();
           };
-          
+
           $scope.resetPagination = function() {
             $scope.currentPage = 1;
             if ($scope.selectedTags) {
@@ -241,11 +242,11 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
             $scope.preview = undefined;
             window.scrollTo(0, 0);
           };
-          
+
           $scope.setSearch = function(x,y) {
             $location.search(x, y);
           }
-          
+
           $scope.selectTag = function(i) {
             $scope.selectedTags = i;
             $scope.resetPagination();
@@ -255,11 +256,11 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
             $scope.preview = undefined;
             $scope.removeFamily();
           };
-          
+
           $scope.selectPreview = function(i) {
             $scope.preview = i;
           };
-          
+
           $scope.selectPreviewVariants = function(i) {
             var styles;
             if ( i.indexOf('italic') > 0 ){
@@ -274,72 +275,80 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
             }
             $scope.previewStyles = styles;
           };
-          
+
           $scope.removeTag = function() {
             $scope.selectedTags = undefined;
             $scope.resetPagination();
             $scope.reset();
             $scope.sendAnalytics();
           };
-          
+
+          $scope.removeSearch = function() {
+            $scope.search = undefined;
+            $scope.resetPagination();
+            $scope.reset();
+            $scope.sendAnalytics();
+            $location.search('search', null);
+          };
+
           $scope.removeFamily = function() {
             $scope.selectedFamily = undefined;
             $scope.resetPagination();
             $location.search('family', null);
           };
-          
+
           $scope.removeCategory = function() {
             $scope.selectedCategory = undefined;
             $scope.resetPagination();
             $location.search('category', null);
           };
-          
+
           $scope.removeVariant = function() {
             $scope.selectedVariants = undefined;
             $scope.resetPagination();
             $location.search('variant', null);
           };
-          
+
           $scope.removeFullVariants = function() {
             $scope.fullVariant = undefined;
             $scope.resetPagination();
           };
-          
+
           $scope.removeVariantCount = function() {
               $scope.selectedVariantCount = undefined;
               $scope.resetPagination();
               $location.search('variantCount', null);
             };
-          
+
           $scope.removeSubset = function() {
             $scope.selectedSubsets = undefined;
             $scope.resetPagination();
             $location.search('subset', null);
           };
-          
+
           $scope.numberOfPages=function(){
             var myFilteredData = $filter('filter')($scope.data,$scope.search,true);
             return Math.ceil(myFilteredData.length/$scope.pageSize);
           };
-          
+
           $scope.numberOfResults=function(){
             var myFilteredData = $filter('filter')($scope.data,$scope.search,true);
             return Math.ceil(myFilteredData.length);
           };
-          
+
           // build out the style attr for the font based on the search parameters and what the font supports
           $scope.familyStyle = function(font) {
-            
+
             var style = 'font-family: "' + font.family + '";';
-            
+
             if ( font.variants.indexOf('regular') < 0 && font.variants.indexOf('italic') >= 0 ) {
               style += 'font-style: italic;';
             }
-            
+
             if ( font.variants.indexOf('regular') < 0 && font.variants.indexOf('italic') < 0 ) {
               style += 'font-weight: '+font.variants[0] +';';
             }
-            
+
             // when users filters by variant
             if ($scope.selectedVariants != undefined) {
               if ($scope.selectedVariants.match('italic') == 'italic') {
@@ -349,18 +358,18 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
                 style += 'font-weight: ' + $scope.selectedVariants +';';
               }
             }
-            
+
             return style
           };
-          
+
           // provide sample in language if subset is filtered or the font doesn't have a latin subset
           $scope.languageSample = function(font) {
             var sample;
-            
+
             if ( font.subsets.indexOf('latin') < 0 ) {
               var sample = $scope.languages[font.subsets];
             }
-            
+
             else {
               for (var key in $scope.languages) {
                 if ($scope.selectedSubsets == key) {
@@ -368,11 +377,11 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
                 }
               }
             }
-            
-            
+
+
             return sample
           }
-          
+
           // build the api call to retrieve the font
           $scope.fontCall = function(i) {
             //get font name
@@ -388,7 +397,7 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
             // if no regular or italic?
             if (i.variants.indexOf('regular') < 0 && i.variants.indexOf('italic') < 0 ) {
               font += ':'+i.variants[0];
-            }            
+            }
             // if font is being previewed, get the full char font
             if ( $scope.preview == i.family ) {
               // get all variants
@@ -397,12 +406,12 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
             // if the custom preview input exists, then get all of the characters
             else if ($scope.customPreview) {
               //font +='&text=' + encodeURIComponent($scope.customPreview);
-              // ^^ this is too slow 
+              // ^^ this is too slow
             }
             // otherwise get this text for the font
             else {
               font +='&text=' + encodeURIComponent(i.family);
-              
+
               for (var key in $scope.languages) {
                 if ($scope.selectedSubsets == key || i.subsets.indexOf('latin') < 0) {
                   font += encodeURIComponent($scope.languages[key]);
@@ -415,7 +424,7 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
             }
             return font;
           };
-          
+
           $scope.clearFilters = function(){
             $scope.selectedTags =  undefined;
             $scope.selectedSubsets = undefined;
@@ -425,26 +434,27 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
             $scope.selectedCategory = undefined;
             $scope.selectedFamily = undefined;
             $scope.customPreview = undefined;
+            $scope.search = undefined;
             $scope.currentPage = 1;
             $location.url($location.path());
             $location.path('');
             $scope.sendAnalytics();
           };
         });
-        
+
         app.filter('startFrom', function() {
           return function(input, start) {
             start = +start;
             return input.slice(start);
           };
         });
-        
+
         app.filter('ceil', function() {
           return function(input) {
             return Math.ceil(input);
           };
         });
-        
+
         // infinite scroll
         $(window).scroll(function() {
           if ($(window).scrollTop() == ( $(document).height() - $(window).height()  ) ) {

--- a/js/app.js
+++ b/js/app.js
@@ -42,7 +42,6 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
     $scope.selectedVariants = $location.search().variant;
     $scope.search = $location.search().search;
     $scope.selectedVariantCount = parseInt($location.search().variantCount);
-    $scope.selectedFamily = $location.search().family;
     if ($.isNumeric(locationSearch)) {
       // if it's a number
       $scope.currentPage = parseInt(locationSearch);
@@ -254,7 +253,6 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
             $scope.sendAnalytics();
             $scope.tagCount = undefined;
             $scope.preview = undefined;
-            $scope.removeFamily();
           };
 
           $scope.selectPreview = function(i) {
@@ -289,12 +287,6 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
             $scope.reset();
             $scope.sendAnalytics();
             $location.search('search', null);
-          };
-
-          $scope.removeFamily = function() {
-            $scope.selectedFamily = undefined;
-            $scope.resetPagination();
-            $location.search('family', null);
           };
 
           $scope.removeCategory = function() {
@@ -432,7 +424,6 @@ app.controller('ctrl', function($scope, $filter, $http, $location, $window) {
             $scope.selectedVariantCount = undefined;
             $scope.fullVariant = undefined;
             $scope.selectedCategory = undefined;
-            $scope.selectedFamily = undefined;
             $scope.customPreview = undefined;
             $scope.search = undefined;
             $scope.currentPage = 1;


### PR DESCRIPTION
First iteration of a data-wide search. Search across fonts names, tags, weights, categories, subsets etc. Replaces select font family option.

![search](https://cloud.githubusercontent.com/assets/2180540/15202457/882517b4-17c8-11e6-8eb6-4b796f4d5baf.gif)
