### PR TITLE
Add test to make sure tags are not subsets

### DIFF
--- a/test/families.test.js
+++ b/test/families.test.js
@@ -1,23 +1,33 @@
 const families = require("../families.json");
+const { subsets } = require("../_data/metadata.json");
 
 // test each family in families.json
 families.forEach(({ family, tags }, index) => {
-  test(family, async () => {
-    expect(family).toBeDefined();
-    expect(tags).toBeDefined();
-
-    // no more than 5 tags
-    if (tags) {
-      expect(tags.length < 6).toBeTruthy();
-    }
-    // tags must be lowercase
-    tags.forEach((tag) => {
-      expect(isNaN(tag[0]) && tag[0] == tag[0].toUpperCase()).toBeFalsy();
+  describe(family, () => {
+    test(`${family} metadata`, async () => {
+      expect(family).toBeDefined();
+      expect(tags).toBeDefined();
+      // make sure families are in alphabetical order
+      const prevFamily = families[index - 1]
+        ? families[index - 1].family
+        : undefined;
+      expect(prevFamily > family).toBeFalsy();
     });
-    // make sure families are in alphabetical order
-    const prevFamily = families[index - 1]
-      ? families[index - 1].family
-      : undefined;
-    expect(prevFamily > family).toBeFalsy();
+
+    for (const tag of tags) {
+      describe("tags", () => {
+        test(`"${family}" must have no more than 5 tags`, async () => {
+          expect(tags.length).toBeLessThan(6);
+        });
+        // tag mut be lowercase
+        test(`"${tag}" must be lowercase`, async () => {
+          expect(tag).toEqual(tag.toLowerCase());
+        });
+        test(`"${tag}" must not be a subset`, async () => {
+          // tag must not match a subset
+          expect(subsets.includes(tag)).toBeFalsy();
+        });
+      });
+    }
   });
 });


### PR DESCRIPTION
Since it's possible to search for subsets, this test will make sure a tag name does not match a subset.